### PR TITLE
Add switch for deprecated rest APIs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The description of the input parameters that can go in the run command is as fol
 9. **host**: It is the IP Address of the host that serves the API. By default the value is < vcenter >
 10. **enable-filtering**: It is used to filter out internal and unrealeased API's so that if service info of the API is still under modification, it is skipped for processing.
 11. **oas** : This parameter is used to specify as to which version of swagger file the user wants to generate. By default the generated files are of version 3 i.e openapi. If the user wants to generate the version 2 files, the parameter needs to be passed explicitly.
+12. **mixed** : This parameter is used to specify whether deprecated APIs are going to be generated. By default the generated files do not contain information regarding the deprecated "/rest" APIs. If the user wants that information to be apparent in the generated files, then the parameter needs to be passed.
 
 ## Contributing
 

--- a/lib/api_endpoint/api_url_processing.py
+++ b/lib/api_endpoint/api_url_processing.py
@@ -1,4 +1,6 @@
 import os
+import threading
+
 import six
 from lib import utils
 from lib.url_processing import UrlProcessing
@@ -6,6 +8,7 @@ from .oas3.api_metamodel2openapi import ApiMetamodel2Openapi
 from .swagger2.api_metamodel2swagger import ApiMetamodel2Swagger
 from .oas3.api_openapi_final_path_processing import ApiOpenapiPathProcessing
 from .swagger2.api_swagger_final_path_processing import ApiSwaggerPathProcessing
+from ..utils import eprint
 
 api_openapi_fpp = ApiOpenapiPathProcessing()
 api_swagg_fpp = ApiSwaggerPathProcessing()
@@ -28,7 +31,6 @@ class ApiUrlProcessing(UrlProcessing):
             service_dict,
             service_url_dict,
             http_error_map,
-            rest_navigation_url,
             enable_filtering,
             spec,
             gen_unique_op_id):
@@ -45,8 +47,14 @@ class ApiUrlProcessing(UrlProcessing):
             if utils.is_filtered(service_info.metadata, enable_filtering):
                 continue
             for operation_id, operation_info in service_info.operations.items():
-                method, url = self.api_get_url_and_method(
-                    operation_info.metadata)
+
+                try:
+                    method, url = self.api_get_url_and_method(
+                        operation_info.metadata)
+                except TypeError as ex:
+                    eprint('Operation is not @VERB annotated %s - %s' % (operation_id, service_url))
+                    eprint(ex)
+                    continue
 
                 # check for query parameters
                 if 'params' in operation_info.metadata[method].elements:

--- a/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
+++ b/lib/api_endpoint/oas3/api_openapi_final_path_processing.py
@@ -117,15 +117,25 @@ class ApiOpenapiPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
-                    q_param = {
-                        'name': key_value[0],
-                        'in': 'query',
-                        'description': key_value[0] + '=' + key_value[1],
-                        'required': True}
-                    q_param['schema'] = {}
-                    q_param['schema']['type'] = 'string'
-                    q_param['schema']['enum'] = [key_value[1]]
-                    query_param.append(q_param)
+                    if len(key_value) == 2:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0] + '=' + key_value[1],
+                            'required': True}
+                        q_param['schema'] = {}
+                        q_param['schema']['type'] = 'string'
+                        q_param['schema']['enum'] = [key_value[1]]
+                        query_param.append(q_param)
+                    else:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0],
+                            'required': True}
+                        q_param['schema'] = {}
+                        q_param['schema']['type'] = 'string'
+                        query_param.append(q_param)
 
                 if new_path in path_dict:
                     new_path_operations = path_dict[new_path].keys()

--- a/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
+++ b/lib/api_endpoint/swagger2/api_swagger_final_path_processing.py
@@ -117,14 +117,22 @@ class ApiSwaggerPathProcessing(PathProcessing):
                 query_param = []
                 for query_parameter in paths_array[1].split('&'):
                     key_value = query_parameter.split('=')
-                    q_param = {
-                        'name': key_value[0],
-                        'in': 'query',
-                        'description': key_value[0] + '=' + key_value[1],
-                        'required': True,
-                        'type': 'string',
-                        'enum': [
-                            key_value[1]]}
+                    if len(key_value) == 2:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0] + '=' + key_value[1],
+                            'required': True,
+                            'type': 'string',
+                            'enum': [
+                                key_value[1]]}
+                    else:
+                        q_param = {
+                            'name': key_value[0],
+                            'in': 'query',
+                            'description': key_value[0],
+                            'required': True,
+                            'type': 'string'}
                     query_param.append(q_param)
 
                 if new_path in path_dict:

--- a/lib/establish_connection.py
+++ b/lib/establish_connection.py
@@ -65,6 +65,14 @@ def get_input_params():
         '--oas',
         default='3',
         help='opeanpi specification version')
+    parser.add_argument(
+        '-mixed',
+        '--mixed',
+        required=False,
+        nargs='?',
+        const=True,
+        default=False,
+        help='api and rest rendering, with rest being deprecated')
     parser.set_defaults(filtering=False)
     args = parser.parse_args()
     metadata_url = args.metadata_url
@@ -105,7 +113,11 @@ def get_input_params():
     if args.oas not in ['2', '3']:
         raise Exception(" Input Valid Specification ")
     SPECIFICATION = args.oas
-    return metadata_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR
+
+    global MIXED
+    MIXED = args.mixed
+
+    return metadata_url, rest_navigation_url, output_dir, verify, enable_filtering, GENERATE_METAMODEL, SPECIFICATION, GENERATE_UNIQUE_OP_IDS, TAG_SEPARATOR, MIXED
 
 
 def get_component_service(connector):

--- a/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
+++ b/lib/rest_endpoint/oas3/rest_openapi_final_path_processing.py
@@ -44,10 +44,12 @@ class RestOpenapiPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
+        file_prefix = '/rest'
+
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/rest' +
+            file_prefix +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/rest_endpoint/rest_deprecation_handler.py
+++ b/lib/rest_endpoint/rest_deprecation_handler.py
@@ -1,0 +1,29 @@
+class RestDeprecationHandler:
+
+    def __init__(self, replacement_map):
+        '''
+        The replacement navigation map is used when MIXED specification is issued (@VERB + an old annotation standard)
+        It contains mappings to url paths, served as replacements. The structure of the map is the following:
+        service -> operation -> method -> raplacement path
+        '''
+        self.replacement_map = replacement_map
+
+    def add_deprecation_information(self, path_obj, package_name, service_name):
+        replacement_path = "<unknown>"
+        path_obj["deprecated"] = True
+
+        # construct file name
+        api_file_name = "api_" + package_name + ".json"
+
+        # Could be a more intelligent resolution - guessing based on key words?
+        operation_map = self.replacement_map.get(service_name)
+        if operation_map is not None and "operationId" in path_obj:
+            method_map = operation_map.get(path_obj["operationId"])
+            if method_map is not None and "method" in path_obj:
+                # get concrete path and format accordingly
+                replacement_path = method_map.get(path_obj["method"])
+                replacement_path = replacement_path.replace("/", "~1")
+                replacement_path = api_file_name + "#/paths/" + replacement_path + "/" + path_obj["method"]
+
+        path_obj["x-vmw-deprecated"] = {"replacement": replacement_path}
+

--- a/lib/rest_endpoint/rest_navigation_handler.py
+++ b/lib/rest_endpoint/rest_navigation_handler.py
@@ -1,0 +1,12 @@
+from lib import utils
+
+class RestNavigationHandler:
+
+    def __init__(self, rest_navigation_url):
+        self.rest_navigation_url = rest_navigation_url
+
+    def get_service_operations(self, service_url):
+        return utils.get_json(self.rest_navigation_url + service_url + '?~method=OPTIONS', False)
+
+    def get_rest_navigation_url(self):
+        return self.rest_navigation_url

--- a/lib/rest_endpoint/rest_url_processing.py
+++ b/lib/rest_endpoint/rest_url_processing.py
@@ -2,6 +2,7 @@ import os
 import six
 from lib import utils
 from lib.url_processing import UrlProcessing
+from . import rest_deprecation_handler
 from .oas3.rest_metamodel2openapi import RestMetamodel2Openapi
 from .swagger2.rest_metamodel2swagger import RestMetamodel2Swagger
 from .oas3.rest_openapi_final_path_processing import RestOpenapiPathProcessing
@@ -27,14 +28,16 @@ class RestUrlProcessing(UrlProcessing):
             service_dict,
             service_url_dict,
             http_error_map,
-            rest_navigation_url,
+            rest_navigation_handler,
             enable_filtering,
             spec,
-            gen_unique_op_id):
+            gen_unique_op_id,
+            deprecation_handler=None):
 
         print('processing package ' + package_name + os.linesep)
         type_dict = {}
         path_list = []
+
         for service_url in service_urls:
             service_name, service_end_point = service_url_dict.get(
                 service_url, None)
@@ -77,12 +80,13 @@ class RestUrlProcessing(UrlProcessing):
                             http_error_map,
                             enable_filtering)
 
+                    if deprecation_handler is not None and service_end_point == "/mixed":
+                        deprecation_handler.add_deprecation_information(path, package_name, service_name)
                     path_list.append(path)
                 continue
             # use rest navigation service to get the REST mappings for a
             # service.
-            service_operations = utils.get_json(
-                rest_navigation_url + service_url + '?~method=OPTIONS', False)
+            service_operations = rest_navigation_handler.get_service_operations(service_url)
             if service_operations is None:
                 continue
 
@@ -109,7 +113,7 @@ class RestUrlProcessing(UrlProcessing):
                     continue
                 url, method = self.find_url(service_operation['links'])
                 url = self.get_service_path_from_service_url(
-                    url, rest_navigation_url)
+                    url, rest_navigation_handler.get_rest_navigation_url())
                 operation_info = service_info.operations.get(operation_id)
 
                 if spec == '2':
@@ -137,6 +141,8 @@ class RestUrlProcessing(UrlProcessing):
                         http_error_map,
                         enable_filtering)
 
+                if deprecation_handler is not None and service_end_point == "/mixed":
+                    deprecation_handler.add_deprecation_information(path, package_name, service_name)
                 path_list.append(path)
         path_dict = self.convert_path_list_to_path_map(path_list)
         self.cleanup(path_dict=path_dict, type_dict=type_dict)

--- a/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
+++ b/lib/rest_endpoint/swagger2/rest_swagger_final_path_processing.py
@@ -49,10 +49,12 @@ class RestSwaggerPathProcessing(PathProcessing):
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
+        file_prefix = '/rest'
+
         utils.write_json_data_to_file(
             output_dir +
             os.path.sep +
-            '/rest' +
+            file_prefix +
             "_" +
             utils.remove_curly_braces(output_filename) +
             '.json',

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -59,6 +59,16 @@ def is_filtered(metadata, enable_filtering):
     return False
 
 
+def combine_dicts_with_list_values(extended, added):
+    for k, v in added.items():
+        list_to_extend = extended.get(k, None)
+        if list_to_extend is None:
+            extended[k] = v
+        else:
+            list_to_extend.extend(v)
+            extended[k] = list(set(list_to_extend))
+
+
 def extract_path_parameters(params, url):
     """
     Return list of field_infos which are path variables, another list of

--- a/test_api_oas.py
+++ b/test_api_oas.py
@@ -388,7 +388,43 @@ class TestApiOpenapiPathProcessing(unittest.TestCase):
         self.api_openapi_path.remove_query_params(path_dict)
         self.assertEqual(path_dict, path_dict_expected)
 
-        # case 2.2: both of them have query parameter
+        # case 2.2: only one of them as query parameter without specified enum value
+        path_dict = {
+            'mock/path1?action': {
+                'post': {
+                    'parameters': []
+                }
+            },
+            'mock/path1': {
+                'get': {
+                    'parameters': []
+                }
+            }
+        }
+        path_dict_expected = {
+            'mock/path1': {
+                'post': {
+                    'parameters': [
+                        {
+                            'name': 'action',
+                            'in': 'query',
+                            'description': 'action',
+                            'required': True,
+                            'schema': {
+                                'type': 'string'
+                            }
+                        }
+                    ]
+                },
+                'get': {
+                    'parameters': []
+                }
+            }
+        }
+        self.api_openapi_path.remove_query_params(path_dict)
+        self.assertEqual(path_dict, path_dict_expected)
+
+        # case 2.3: both of them have query parameter
         path_dict = {
             'mock/path1?action=mock_action_1':{
                 'post':{

--- a/test_api_swagger.py
+++ b/test_api_swagger.py
@@ -341,8 +341,42 @@ class TestApiSwaggerFinalPath(unittest.TestCase):
         }
         self.api_swagger_path.remove_query_params(path_dict)
         self.assertEqual(path_dict, path_dict_expected)
+
+        # case 2.2: only one of them as query parameter without specified enum value
+        path_dict = {
+            'mock/path1?action':{
+                'post':{
+                    'parameters' : []
+                }
+            },
+            'mock/path1':{
+                'get':{
+                    'parameters' : []
+                }
+            }
+        }
+        path_dict_expected = {
+            'mock/path1': {
+                'post': {
+                    'parameters': [
+                        {
+                            'name': 'action',
+                            'in': 'query',
+                            'description':'action',
+                            'required': True,
+                            'type': 'string'
+                        }
+                    ]
+                },
+                'get': {
+                    'parameters' : []
+                }
+            }
+        }
+        self.api_swagger_path.remove_query_params(path_dict)
+        self.assertEqual(path_dict, path_dict_expected)
     
-        # case 2.2: both of them have query parameter
+        # case 2.3: both of them have query parameter
         path_dict = {
             'mock/path1?action=mock_action_1':{
                 'post':{

--- a/test_rest_deprecation.py
+++ b/test_rest_deprecation.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest import mock
+
+from lib.rest_endpoint.rest_deprecation_handler import RestDeprecationHandler
+
+
+class TestRestDeprecationHandler(unittest.TestCase):
+
+    sample_package = "vsphere"
+    sample_service = "com.test.service"
+    sample_operation = "list"
+    sample_method = "get"
+    sample_path = "/com/test/sample/list"
+    replacement_map = {sample_service: {sample_operation: {sample_method: sample_path}}}
+    rest_deprecation_handler = RestDeprecationHandler(replacement_map)
+
+    def test_rest_deprecation(self):
+        path_obj = {"operationId": self.sample_operation, "method": self.sample_method}
+        self.rest_deprecation_handler.add_deprecation_information(path_obj, self.sample_package, self.sample_service)
+
+        self.assertEqual(path_obj['deprecated'], True)
+        self.assertEqual(path_obj["x-vmw-deprecated"]["replacement"], "api_vsphere.json#/paths/~1com~1test~1sample~1list/get")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,24 @@
+import unittest
+
+from lib import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_combine_dicts_with_list_values(self):
+        extended = {"1": ["1", "2", "3"],
+                    "2": ["4", "5", "6"]}
+        added = {"3": ["8", "9"],
+                 "2": ["4", "5", "6", "7"]}
+        expected = {"1": ["1", "2", "3"],
+                    "2": ["4", "5", "6", "7"],
+                    "3": ["8", "10"]}
+        utils.combine_dicts_with_list_values(extended, added)
+
+        self.assertEqual(extended.get("1").sort(), expected.get("1").sort())
+        self.assertEqual(extended.get("2").sort(), expected.get("2").sort())
+        self.assertEqual(extended.get("3").sort(), expected.get("3").sort())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some of the apparent APIs contain Auto REST descriptions (obtained via
the navigation service) or @RequestMapping annotations, both of which
were later on updated with the new @VERB annotations, essentially,
making the old ones deprecated.

The following work introduces a switch - the 'mixed' parameter, as
described in the README file, which allows generation of the deprecated
APIs. Priorly, the deprecated APIs were not generated at all.